### PR TITLE
fix: address Node.js 20 action deprecation warnings (June 2 deadline)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -61,7 +61,7 @@ jobs:
         run: rm -f _site/CNAME
 
       - name: Deploy to GitHub Pages (preview)
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
   bundler-audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Pins `peaceiris/actions-gh-pages` from `@v4` → `@v4.1.0`, which switched its runtime to `node24` (upstream PR [#1147](https://github.com/peaceiris/actions-gh-pages/pull/1147)). The floating `@v4` tag still pointed to v4.0.0 (node20) because the maintainer released v4.1.0 without updating it.
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to the Gitleaks step — no Node.js 24-compatible release exists yet for `gitleaks/gitleaks-action@v2`. This opts in now so we get a warning if it breaks rather than a silent failure on June 2nd.

## Context

GitHub is forcing all actions to Node.js 24 by default on **2026-06-02**. Two actions were triggering the deprecation warning:

| Action | Fix |
|---|---|
| `peaceiris/actions-gh-pages@v4` | Pinned to `@v4.1.0` (uses `node24`) |
| `gitleaks/gitleaks-action@v2` | `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` added |

The Gitleaks env var should be removed once the maintainer cuts a `node24`-native release.

## Test plan

- [ ] Deploy and Preview Deploy workflows complete without Node.js 20 deprecation warnings
- [ ] Security/Gitleaks job runs successfully under Node.js 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)