### PR TITLE
chore(ci): add concurrency cancellation and npm caching

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -11,6 +11,10 @@ on:
 
 permissions: { }
 
+concurrency:
+  group: a11y-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pa11y:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: { }
 
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   super-linter:
     runs-on: ubuntu-latest
@@ -80,6 +84,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -110,6 +115,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -129,6 +135,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- Add `concurrency` groups to `lint.yml` and `accessibility.yml` so stale PR runs are cancelled when a new commit is pushed, while `push`-to-main and `schedule` runs are never interrupted
- Add `cache: "npm"` to the three `setup-node` steps in `lint.yml` (`node-lint`, `css-tests`, `build-assets`) that were missing it — consistent with the pattern already used in `deploy.yml` and `preview-deploy.yml`

## Test plan

- [ ] Push a commit to an open PR and verify a second push cancels the first run in the Lint and Accessibility workflow tabs
- [ ] Confirm `push` to `main` runs complete without cancellation
- [ ] Confirm the weekly `schedule` accessibility run completes without cancellation
- [ ] Verify "Set up Node" steps show a cache hit on second runs (Actions log: "Cache restored successfully")

🤖 Generated with [Claude Code](https://claude.com/claude-code)