### PR TITLE
chore(deps): remove no-op overrides and add Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,20 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      postcss:
+        patterns:
+          - "postcss*"
+          - "autoprefixer"
+      stylelint:
+        patterns:
+          - "stylelint*"
+      pa11y:
+        patterns:
+          - "pa11y*"
+      playwright:
+        patterns:
+          - "@playwright/*"
     ignore:
       # Ignore major version updates for now
       - dependency-name: "*"
@@ -68,3 +82,7 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      actions:
+        patterns:
+          - "actions/*"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "pa11y": {
       "bfj": "7.0.2"
     },
+    "lodash": "^4.18.1",
     "minimatch@3.1.5": {
       "brace-expansion": "^1.1.14"
     }

--- a/package.json
+++ b/package.json
@@ -61,25 +61,8 @@
     "pa11y": {
       "bfj": "7.0.2"
     },
-    "lodash": "^4.18.1",
     "minimatch@3.1.5": {
       "brace-expansion": "^1.1.14"
-    },
-    "markdownlint-cli": {
-      "brace-expansion": "^5.0.6"
-    },
-    "purgecss": {
-      "brace-expansion": "^5.0.6"
-    },
-    "axios": "^1.16.1",
-    "basic-ftp": "^5.3.1",
-    "fast-uri": "^3.1.2",
-    "ip-address": "^10.2.0",
-    "puppeteer-core": {
-      "ws": "^8.21.0"
-    },
-    "selenium-webdriver": {
-      "ws": "^8.21.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Remove 9 no-op `overrides`** from `package.json` — these 9 entries were added during a previous vulnerability cleanup but upstream packages have since caught up. `npm ls` confirms none show the `overridden` label anymore, meaning they weren't protecting anything. `npm audit` still shows **0 vulnerabilities** after removal.
- **Keep 2 active overrides** that are still doing real work:
  - `pa11y → bfj@7.0.2` (actively overrides pa11y's `~9.1.3` requirement)
  - `minimatch@3.1.5 → brace-expansion@^1.1.14` (prevents ReDoS via clean-css-cli → glob@7.2.3 path)
- **Add Dependabot `groups`** to batch related npm packages into single PRs: `postcss*`, `stylelint*`, `pa11y*`, `@playwright/*`, and `actions/*` for GitHub Actions

## Test plan

- [ ] Confirm `npm audit` shows 0 vulnerabilities on the branch
- [ ] Confirm `npm ls bfj` still shows `bfj@7.0.2 overridden` (the override is still in place)
- [ ] Confirm `npm ls brace-expansion` still shows `brace-expansion@1.1.14` under `minimatch@3.1.5 overridden`
- [ ] Trigger a Dependabot run (or wait for next schedule) and confirm related packages appear as grouped PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)