### PR TITLE
fix(js): harden error handling in projects.js and fix heading-order violation

### DIFF
--- a/js/mailchimp-embed.js
+++ b/js/mailchimp-embed.js
@@ -1,9 +1,10 @@
 !(function (c, h, i, m, p) {
-  ((m = c.createElement(h)),
-    (p = c.getElementsByTagName(h)[0]),
-    (m.async = 1),
-    (m.src = i),
-    p.parentNode.insertBefore(m, p));
+  m = c.createElement(h);
+  p = c.getElementsByTagName(h)[0];
+  if (!p || !p.parentNode) return;
+  m.async = 1;
+  m.src = i;
+  p.parentNode.insertBefore(m, p);
 })(
   document,
   "script",

--- a/js/projects.js
+++ b/js/projects.js
@@ -124,7 +124,7 @@
       );
       githubLink.textContent = "GitHub";
 
-      const title = document.createElement("h4");
+      const title = document.createElement("h3");
       title.className = "projects-title";
       title.textContent = project.display_name || project.name;
 
@@ -166,9 +166,13 @@
 
     function loadProjects() {
       fetch("/js/projects.json")
-        .then((r) => r.json())
+        .then((r) => {
+          if (!r.ok) throw new Error("projects.json responded " + r.status);
+          return r.json();
+        })
         .then((projects) => {
           const container = document.getElementById("project-container");
+          if (!container) return;
           container.innerHTML = "";
           projects.forEach((p) => container.appendChild(buildFeaturedCard(p)));
 
@@ -182,13 +186,15 @@
           updateFilterBar();
           applyFilter(getActiveFilter());
         })
-        .catch(() => {
+        .catch((err) => {
+          console.error("[projects] Failed to load featured projects:", err);
           const container = document.getElementById("project-container");
-          const err = document.createElement("div");
-          err.className = "col-12 text-center";
-          err.innerHTML =
+          if (!container) return;
+          const errDiv = document.createElement("div");
+          errDiv.className = "col-12 text-center";
+          errDiv.innerHTML =
             "<p>Sorry, we couldn't load the projects. Please try again later.</p>";
-          container.appendChild(err);
+          container.appendChild(errDiv);
         });
     }
 
@@ -226,7 +232,7 @@
       );
       githubLink.textContent = "GitHub";
 
-      const titleEl = document.createElement("h4");
+      const titleEl = document.createElement("h3");
       titleEl.className = "projects-title";
       titleEl.textContent = displayName;
 
@@ -256,17 +262,25 @@
 
     function loadGitHubProjects() {
       Promise.all([
-        fetch(
-          "https://api.github.com/orgs/CivicTechWR/repos?per_page=100",
-        ).then((r) => r.json()),
+        fetch("https://api.github.com/orgs/CivicTechWR/repos?per_page=100").then(
+          (r) => {
+            if (!r.ok) throw new Error("GitHub API responded " + r.status);
+            return r.json();
+          },
+        ),
         fetch("/js/github_overrides.json")
-          .then((r) => r.json())
-          .catch(() => ({})),
+          .then((r) => {
+            if (!r.ok) throw new Error("github_overrides.json responded " + r.status);
+            return r.json();
+          })
+          .catch((err) => {
+            console.error("[projects] Could not load github_overrides.json, overrides will not be applied:", err);
+            return {};
+          }),
       ])
         .then(([repos, overrides]) => {
-          const container = document.getElementById(
-            "github-projects-container",
-          );
+          const container = document.getElementById("github-projects-container");
+          if (!container) return;
           container.innerHTML = "";
 
           repos
@@ -288,15 +302,15 @@
           updateFilterBar();
           applyFilter(getActiveFilter());
         })
-        .catch(() => {
-          const container = document.getElementById(
-            "github-projects-container",
-          );
-          const err = document.createElement("div");
-          err.className = "col-12 text-center";
-          err.innerHTML =
+        .catch((err) => {
+          console.error("[projects] Failed to load GitHub projects:", err);
+          const container = document.getElementById("github-projects-container");
+          if (!container) return;
+          const errDiv = document.createElement("div");
+          errDiv.className = "col-12 text-center";
+          errDiv.innerHTML =
             "<p>Sorry, we couldn't load the other projects. Please try again later.</p>";
-          container.appendChild(err);
+          container.appendChild(errDiv);
         });
     }
 


### PR DESCRIPTION
## Summary

Findings from a silent-failure audit and accessibility review (axe-core) of the two JS files extracted as part of the CSP work.

### `projects.js`
- **HTTP errors not detected**: Both `fetch()` calls lacked `r.ok` checks — a GitHub API rate-limit (403) or broken Jekyll build serving a 404 for `projects.json` would pass a malformed response body to the card builder, crash inside `.then()`, trigger `.catch()`, then crash *again* in `.catch()` (see below), resulting in a blank section with zero user feedback
- **Crash in catch block**: `.catch()` called `getElementById()` without a null guard, then immediately called `.appendChild()` on the result — the error handler was itself a source of uncaught TypeErrors
- **`github_overrides.json` silent swallow**: `.catch(() => ({}))` suppressed all failures (404, 500, parse error) with no logging, causing hidden repos to silently reappear and overrides to vanish
- **h4 → h3**: Both `buildFeaturedCard` and `buildGitHubCard` used `h4` under `h2` section headings, skipping `h3` — flagged as a `heading-order` axe violation on `projects.html`

### `mailchimp-embed.js`
- **Unguarded `.parentNode` access**: `getElementsByTagName("script")[0]` returns `undefined` when no script elements are in the DOM at call time; added null guard before `.parentNode.insertBefore()`

## Test plan
- [ ] Projects page loads and renders cards correctly
- [ ] No axe `heading-order` violations on projects.html
- [ ] No console errors on normal page load
- [ ] Newsletter signup still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)