### PR TITLE
chore(ci): bump Node.js 22 → 24 in e2e and security workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install Node dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,8 @@ EOF
 ```
 **Rule:** The required check name must match the job's `name:` field (display name), not the job key (YAML key).
 
-**`pa11y` failing with "Chrome folder exists but executable missing"**
-The pa11y job uses puppeteer-core, which does not auto-download Chrome. The workflow caches `~/.cache/puppeteer` via `actions/cache` keyed on `package.json`, and runs `npx puppeteer browsers install chrome` only on a cache miss. If the cache becomes corrupt (folder present, binary missing), delete the cache entry in the GitHub Actions UI (Settings → Caches) and rerun. If the cache step is missing entirely, add it back — see `accessibility.yml` for the current pattern.
+**`pa11y` failing with Chrome-related errors**
+The pa11y job uses `google-chrome-stable` and `chromedriver` pre-installed on the ubuntu runner. The `Configure Chrome for accessibility testing` step sets `PUPPETEER_EXECUTABLE_PATH` to the system Chrome (for pa11y-ci) and symlinks the system `chromedriver` binary into `node_modules/chromedriver/lib/chromedriver/` (for `@axe-core/cli`). If pa11y fails with a Chrome or chromedriver error, verify the step is present in `accessibility.yml` and that `google-chrome-stable` and `chromedriver` are available on the runner (both are pre-installed on ubuntu-latest).
 
 **`super-linter` / `SHELL_SHFMT` failing on new shell scripts**
 All `.sh` files must use **tabs** for indentation (shfmt default). Run `shfmt -w <script.sh>` locally before committing.


### PR DESCRIPTION
## Summary

- Bumps `node-version` from `"22"` to `"24"` in `e2e.yml` and `security.yml`
- All other workflows (`lint.yml`, `accessibility.yml`, `deploy.yml`, `preview-deploy.yml`) were already on Node.js 24
- Addresses the June 2 Node.js deprecation deadline

## Test plan

- [ ] E2E tests pass with Node.js 24
- [ ] npm audit passes with Node.js 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)