### PR TITLE
fix(data): update PECH and WR Votes project URLs and years

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -8,18 +8,18 @@
   url: https://www.connectedkw.com/
   github: https://github.com/CivicTechWR
 - name: Waterloo Region Votes
-  year: [2018]
+  year: [2018, 2022, 2026]
   role: ["Software", "Sponsor"]
   tags: ["civic-engagement", "elections", "open-data"]
   description: "A voter information hub for Waterloo Region municipal elections — featuring candidate details, ward maps, and address lookup tools to help residents navigate their local ballot."
   logo: /images/regionvotes.webp
   url: https://www.waterlooregionvotes.org/
-  github: https://github.com/CivicTechWR
+  github: https://github.com/CivicTechWR/WRvotes
 - name: Plan to End Chronic Homelessness (PECH)
   year: [2024]
   role: ["Software"]
   tags: ["community", "open-data"]
   description: "A civic tech platform tracking and visualizing efforts toward ending chronic homelessness in Waterloo Region by 2030, with data dashboards, housing program updates, and community spotlights."
   logo: /images/hacknight-7.webp
-  url: https://github.com/CivicTechWR/project-pech
+  url: https://project-pech-civictech.vercel.app
   github: https://github.com/CivicTechWR/project-pech


### PR DESCRIPTION
## Summary

- **PECH**: `url` now points to the live app at `https://project-pech-civictech.vercel.app` instead of the GitHub repo
- **WR Votes**: `github` updated to `CivicTechWR/WRvotes` (the active repo for the 2026 election); `year` updated to `[2018, 2022, 2026]`

## Test plan

- [x] `npm run test:e2e` — 76/76 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)