### PR TITLE
fix(projects): join year arrays in Liquid template on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@ description: "CivicTechWR brings together people from different sectors to work 
                       rel="noopener noreferrer"
                       >{{project.name}}</a
                     >
-                    <small class="projects-tag">Year: {{project.year}}</small>
+                    <small class="projects-tag">Year: {{project.year | join: ", "}}</small>
                   </div>
                   <a href="{{project.url}}">
                     <img
@@ -304,7 +304,7 @@ description: "CivicTechWR brings together people from different sectors to work 
                       rel="noopener noreferrer"
                       >{{project.name}}</a
                     >
-                    <small class="projects-tag">Year: {{project.year}}</small>
+                    <small class="projects-tag">Year: {{project.year | join: ", "}}</small>
                   </div>
                   <a href="{{project.url}}">
                     <img


### PR DESCRIPTION
## Summary

Codex flagged in PR #120 that `{{project.year}}` renders space-separated in Liquid when the value is an array. WR Votes now has `year: [2018, 2022, 2026]`, which was producing "Year: 2018 2022 2026" on the homepage Liquid-rendered project cards.

Applied `| join: ", "` to both occurrences so it renders as "Year: 2018, 2022, 2026".

Note: the JavaScript-rendered cards on `/projects.html` were already correct — `buildFeaturedCard()` explicitly calls `.join(", ")`.

## Test plan

- [x] `npm run test:e2e` — 76/76 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)