### PR TITLE
fix(luma): treat event URL in LOCATION field as hidden address

### DIFF
--- a/_plugins/fetch_luma_event.rb
+++ b/_plugins/fetch_luma_event.rb
@@ -188,6 +188,10 @@ module CivicTechWR
     # Derive a short location: "165 King St W, Kitchener" from
     # "165 King St W, Kitchener, ON N2G 1A7, Canada"
     def short_location(location)
+      # Luma substitutes the event URL in LOCATION when the address is hidden
+      # until RSVP — treat any URL as "no physical address provided"
+      return "165 King St W, Kitchener" if location.to_s.start_with?("https://", "http://")
+
       parts = location.split(",").map(&:strip)
       # Take street + city (first two non-empty comma-delimited parts)
       short = parts.first(2).join(", ")

--- a/tests/ruby/luma_event_generator_test.rb
+++ b/tests/ruby/luma_event_generator_test.rb
@@ -51,6 +51,9 @@ assert_equal "165 King St W, Kitchener", short, "Should extract short address fr
 short_fallback = generator.send(:short_location, "")
 assert_equal "165 King St W, Kitchener", short_fallback, "Should return fallback when location is empty"
 
+short_url = generator.send(:short_location, "https://luma.com/event/evt-abc123")
+assert_equal "165 King St W, Kitchener", short_url, "Should return fallback when Luma substitutes event URL for hidden address"
+
 # --- unescape_ical: backslash-escape sequences ---
 unescaped = generator.send(:unescape_ical, "Kitchener\\, Ontario\\nCanada")
 assert_equal "Kitchener, Ontario\nCanada", unescaped, "Should unescape iCal text escapes"


### PR DESCRIPTION
## Summary

Luma puts the event URL (e.g. `https://luma.com/event/evt-...`) in the iCal `LOCATION` field when the physical address is hidden until RSVP. `short_location()` was rendering this URL verbatim in the meeting card location row.

**Root cause:** `short_location("https://luma.com/event/evt-NbcGCBB4rGAlCsS")` has no commas, so `split(",")` returns the full URL as a single non-empty part — the fallback never triggered.

**Fix:** Return the hardcoded fallback immediately if the location string starts with `https://` or `http://`.

Verified on live site: location was showing `https://luma.com/event/evt-NbcGCBB4rGAlCsS`.

## Test plan

- [x] `npm run test:luma` — passes, including new assertion for URL-as-location case

🤖 Generated with [Claude Code](https://claude.com/claude-code)