### PR TITLE
feat(ci): auto-approve and queue auto-merge for Dependabot minor/patch PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,12 +1,11 @@
 # Auto-approve and enable auto-merge for Dependabot PRs
+# Based on: https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions
 # This workflow runs when Dependabot creates or updates a PR
-# It will auto-approve and enable auto-merge if CI passes
+# It will auto-approve and enable auto-merge for minor/patch updates after CI passes
 
 name: Dependabot Auto-Merge
 
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: pull_request
 
 permissions: {}
 
@@ -18,21 +17,25 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Fetch Dependabot metadata
+      - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Approve PR
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' || 
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+      - name: Enable auto-merge for Dependabot PRs
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' || 
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,11 +1,14 @@
 # Auto-approve and enable auto-merge for Dependabot PRs
 # Based on: https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions
-# This workflow runs when Dependabot creates or updates a PR
-# It will auto-approve and enable auto-merge for minor/patch updates after CI passes
+# Uses pull_request_target so the workflow always runs from main (base branch),
+# preventing a Dependabot action-bump PR from executing an unreviewed workflow version.
+# Safe because this workflow never checks out or runs any PR code.
 
 name: Dependabot Auto-Merge
 
-on: pull_request
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions: {}
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+# Auto-approve and enable auto-merge for Dependabot PRs
+# This workflow runs when Dependabot creates or updates a PR
+# It will auto-approve and enable auto-merge if CI passes
+
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/DEPENDABOT_AUTO_MERGE.md
+++ b/docs/DEPENDABOT_AUTO_MERGE.md
@@ -1,0 +1,68 @@
+# Dependabot Auto-Merge Setup
+
+This PR enables automatic merging of Dependabot PRs for minor and patch updates.
+
+## What's Included
+
+### 1. Updated `.github/dependabot.yml`
+- Added `groups` configuration for npm, bundler, and GitHub Actions
+- Groups minor and patch updates together
+- Auto-merge will only apply to these update types
+- Major updates still require manual review
+
+### 2. New Workflow `.github/workflows/dependabot-auto-merge.yml`
+- Auto-approves Dependabot PRs for minor/patch updates
+- Enables auto-merge after CI passes
+- Only runs for `dependabot[bot]` actor
+
+## Required Repository Settings
+
+⚠️ **Action Required**: A repository admin needs to enable auto-merge in GitHub settings:
+
+1. Go to **Settings** → **General**
+2. Scroll to **Pull Requests** section
+3. Check ✅ **Allow auto-merge**
+4. Optionally, also check:
+   - ✅ **Allow squash merging** (recommended)
+   - ✅ **Automatically delete head branches**
+
+## How It Works
+
+1. Dependabot creates a PR for a minor or patch update
+2. The `dependabot-auto-merge` workflow runs:
+   - Checks if the update is minor or patch
+   - Auto-approves the PR
+   - Enables auto-merge with squash
+3. Once all CI checks pass, the PR auto-merges
+4. Branch is automatically deleted (if setting enabled)
+
+## Benefits
+
+- ✅ Reduces manual review overhead for safe updates
+- ✅ Keeps dependencies up-to-date automatically
+- ✅ Only applies to minor/patch (backwards-compatible changes)
+- ✅ Still requires CI to pass before merging
+- ✅ Major updates still require manual review
+
+## Existing Dependabot PRs
+
+After this PR merges and auto-merge is enabled in settings, you can manually enable auto-merge on existing Dependabot PRs that have passed CI:
+
+```bash
+# For each passing Dependabot PR
+gh pr merge <PR_NUMBER> --auto --squash
+```
+
+Or the workflow will automatically handle new Dependabot PRs going forward.
+
+## Testing
+
+After enabling auto-merge in repository settings:
+1. Wait for the next Dependabot PR to be created
+2. Verify the workflow runs and approves it
+3. Verify auto-merge is enabled
+4. Verify it merges automatically after CI passes
+
+## Related PRs
+
+- #74, #73, #72, #71, #69, #68, #67, #66, #65 - Existing Dependabot PRs that can use auto-merge

--- a/docs/DEPENDABOT_AUTO_MERGE.md
+++ b/docs/DEPENDABOT_AUTO_MERGE.md
@@ -1,19 +1,16 @@
 # Dependabot Auto-Merge Setup
 
-This PR enables automatic merging of Dependabot PRs for minor and patch updates.
+This PR enables automatic merging of Dependabot PRs for minor and patch updates, following [GitHub's official automation guide](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions).
 
 ## What's Included
 
-### 1. Updated `.github/dependabot.yml`
-- Added `groups` configuration for npm, bundler, and GitHub Actions
-- Groups minor and patch updates together
-- Auto-merge will only apply to these update types
-- Major updates still require manual review
-
-### 2. New Workflow `.github/workflows/dependabot-auto-merge.yml`
+### New Workflow `.github/workflows/dependabot-auto-merge.yml`
+- Uses `dependabot/fetch-metadata` (SHA-pinned to v2.5.0) to get update type
 - Auto-approves Dependabot PRs for minor/patch updates
-- Enables auto-merge after CI passes
+- Enables auto-merge after approval
+- Uses `pull_request` trigger (not `pull_request_target`)
 - Only runs for `dependabot[bot]` actor
+- Workflow-level permissions locked to `{}` — write access scoped to the job only
 
 ## Required Repository Settings
 
@@ -22,47 +19,52 @@ This PR enables automatic merging of Dependabot PRs for minor and patch updates.
 1. Go to **Settings** → **General**
 2. Scroll to **Pull Requests** section
 3. Check ✅ **Allow auto-merge**
-4. Optionally, also check:
-   - ✅ **Allow squash merging** (recommended)
+4. Recommended additional settings:
+   - ✅ **Allow squash merging**
    - ✅ **Automatically delete head branches**
 
 ## How It Works
 
 1. Dependabot creates a PR for a minor or patch update
-2. The `dependabot-auto-merge` workflow runs:
-   - Checks if the update is minor or patch
-   - Auto-approves the PR
-   - Enables auto-merge with squash
-3. Once all CI checks pass, the PR auto-merges
-4. Branch is automatically deleted (if setting enabled)
+2. The `dependabot-auto-merge` workflow runs on `pull_request` event
+3. Workflow fetches metadata to determine update type
+4. If minor/patch update:
+   - Workflow auto-approves the PR
+   - Workflow enables auto-merge with squash
+5. Once all required CI checks pass, the PR auto-merges
+6. Branch is automatically deleted (if setting enabled)
 
 ## Benefits
 
 - ✅ Reduces manual review overhead for safe updates
 - ✅ Keeps dependencies up-to-date automatically
 - ✅ Only applies to minor/patch (backwards-compatible changes)
-- ✅ Still requires CI to pass before merging
+- ✅ Still requires all CI checks to pass before merging
 - ✅ Major updates still require manual review
+- ✅ Follows GitHub's recommended automation pattern
 
 ## Existing Dependabot PRs
 
-After this PR merges and auto-merge is enabled in settings, you can manually enable auto-merge on existing Dependabot PRs that have passed CI:
+After this PR merges and auto-merge is enabled in repository settings, manually enable auto-merge on existing Dependabot PRs that have passed CI:
 
 ```bash
 # For each passing Dependabot PR
+gh pr review --approve <PR_NUMBER>
 gh pr merge <PR_NUMBER> --auto --squash
 ```
-
-Or the workflow will automatically handle new Dependabot PRs going forward.
 
 ## Testing
 
 After enabling auto-merge in repository settings:
-1. Wait for the next Dependabot PR to be created
+1. Trigger a Dependabot PR (or wait for the next scheduled run)
 2. Verify the workflow runs and approves it
 3. Verify auto-merge is enabled
-4. Verify it merges automatically after CI passes
+4. Verify it merges automatically after all CI checks pass
 
-## Related PRs
+## Security Considerations
 
-- #74, #73, #72, #71, #69, #68, #67, #66, #65 - Existing Dependabot PRs that can use auto-merge
+- Uses `pull_request` trigger (not `pull_request_target`) for safety
+- Only runs when actor is `dependabot[bot]`
+- Requires all branch protection rules to pass before merging
+- Only auto-merges semver-minor and semver-patch updates
+

--- a/docs/DEPENDABOT_AUTO_MERGE.md
+++ b/docs/DEPENDABOT_AUTO_MERGE.md
@@ -8,7 +8,7 @@ This PR enables automatic merging of Dependabot PRs for minor and patch updates,
 - Uses `dependabot/fetch-metadata` (SHA-pinned to v2.5.0) to get update type
 - Auto-approves Dependabot PRs for minor/patch updates
 - Enables auto-merge after approval
-- Uses `pull_request` trigger (not `pull_request_target`)
+- Uses `pull_request_target` so the workflow always runs from main — prevents a Dependabot action-bump PR from executing an unreviewed version of this workflow (safe: no PR code is checked out)
 - Only runs for `dependabot[bot]` actor
 - Workflow-level permissions locked to `{}` — write access scoped to the job only
 
@@ -26,7 +26,7 @@ This PR enables automatic merging of Dependabot PRs for minor and patch updates,
 ## How It Works
 
 1. Dependabot creates a PR for a minor or patch update
-2. The `dependabot-auto-merge` workflow runs on `pull_request` event
+2. The `dependabot-auto-merge` workflow runs on `pull_request_target` event
 3. Workflow fetches metadata to determine update type
 4. If minor/patch update:
    - Workflow auto-approves the PR
@@ -62,7 +62,7 @@ After enabling auto-merge in repository settings:
 
 ## Security Considerations
 
-- Uses `pull_request` trigger (not `pull_request_target`) for safety
+- Uses `pull_request_target` so the workflow runs from the trusted base branch, not the PR branch
 - Only runs when actor is `dependabot[bot]`
 - Requires all branch protection rules to pass before merging
 - Only auto-merges semver-minor and semver-patch updates

--- a/docs/DEPENDABOT_AUTO_MERGE.md
+++ b/docs/DEPENDABOT_AUTO_MERGE.md
@@ -52,7 +52,6 @@ After this PR merges and auto-merge is enabled in repository settings, manually 
 gh pr review --approve <PR_NUMBER>
 gh pr merge <PR_NUMBER> --auto --squash
 ```
-
 ## Testing
 
 After enabling auto-merge in repository settings:
@@ -67,4 +66,3 @@ After enabling auto-merge in repository settings:
 - Only runs when actor is `dependabot[bot]`
 - Requires all branch protection rules to pass before merging
 - Only auto-merges semver-minor and semver-patch updates
-


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependabot-auto-merge.yml` — when Dependabot opens a minor or patch PR, the workflow auto-approves it and enables GitHub's auto-merge queue
- Pins `dependabot/fetch-metadata` to SHA `21025c705c08248db411dc16f3619e6b5f9ea21a` (v2.5.0) per repo SHA-pinning convention
- Workflow-level permissions locked to `{}` — write access (`contents`, `pull-requests`) scoped to the job only
- No changes to `.github/dependabot.yml` — existing specific groupings (postcss, stylelint, pa11y, playwright, actions) preserved

## Important caveat — code owner gate

The bot's approval satisfies one reviewer slot, but the branch protection requires a code owner (`@CivicTechWR/website`) to approve. The `github-actions[bot]` is not in that team. Auto-merge will queue but won't fire until a code owner also approves.

Practical effect: this removes the need to manually run `gh pr merge --auto --squash` for every Dependabot PR. A code owner still needs to review once, but after that the merge executes automatically when CI passes.

## Required one-time setup

A repo admin needs to enable auto-merge in repository settings if not already on:
**Settings → General → Pull Requests → Allow auto-merge** ✅

## Testing

After merge, the next Dependabot PR should trigger the `Dependabot Auto-Merge` workflow, which will auto-approve and call `gh pr merge --auto --squash`. Check the Actions tab to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)