### PR TITLE
fix(a11y): replace aria-label with label elements and add footer role

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="footer-redesign">
+<footer class="footer-redesign" role="contentinfo">
   <div class="footer-redesign-container">
     <div class="footer-col footer-brand">
       <a href="https://civictechwr.org">
@@ -38,6 +38,7 @@
           target="_blank"
         >
           <div id="mc_embed_signup_scroll_footer">
+            <label for="mce-EMAIL" class="sr-only">Email Address</label>
             <input
               type="email"
               name="EMAIL"
@@ -45,7 +46,6 @@
               id="mce-EMAIL"
               placeholder="your@email.com"
               required=""
-              aria-label="Email Address"
             />
             <div aria-hidden="true" class="mc-honeypot">
               <input

--- a/_includes/newsletter-signup.html
+++ b/_includes/newsletter-signup.html
@@ -30,6 +30,7 @@
             target="_blank"
           >
             <div class="newsletter-form-wrapper">
+              <label for="mce-EMAIL-main" class="sr-only">Email Address</label>
               <input
                 type="email"
                 name="EMAIL"
@@ -37,7 +38,6 @@
                 id="mce-EMAIL-main"
                 placeholder="your@email.com"
                 required=""
-                aria-label="Email Address"
               />
               <div aria-hidden="true" class="mc-honeypot">
                 <input

--- a/tests/e2e/newsletter-form.spec.js
+++ b/tests/e2e/newsletter-form.spec.js
@@ -19,7 +19,8 @@ for (const page of PAGES_WITH_NEWSLETTER) {
       await expect(input).toBeVisible();
       await expect(input).toHaveAttribute("type", "email");
       await expect(input).toHaveAttribute("required");
-      await expect(input).toHaveAttribute("aria-label", "Email Address");
+      // Label association via <label for> replaces aria-label
+      await expect(pw.locator('label[for="mce-EMAIL"]')).toContainText("Email Address");
     });
 
     test("subscribe button is present", async ({ page: pw }) => {


### PR DESCRIPTION
## Summary

Final item from the codebase analysis action plan — minor accessibility polish.

- **`_includes/footer.html`**: added `role="contentinfo"` to `<footer>` (makes the landmark explicit rather than inferred); replaced `aria-label="Email Address"` on the email input with `<label for="mce-EMAIL" class="sr-only">Email Address</label>`
- **`_includes/newsletter-signup.html`**: same label change for the newsletter section form (`id="mce-EMAIL-main"`)
- **`tests/e2e/newsletter-form.spec.js`**: updated the email input test to assert `label[for="mce-EMAIL"]` contains "Email Address" instead of checking `aria-label` attribute

Labels use the existing `.sr-only` class (visually hidden, `1px × 1px` clip) so the compact inline form layout is unchanged. The `<label for>` association is stronger than `aria-label` — it's a native DOM relationship that browsers, screen readers, and automated a11y tools all recognise.

## Test plan

- [x] All 27 newsletter form E2E tests pass locally
- [x] `npm run lint` clean
- [ ] CI green (pa11y will also benefit from the improved label association)

🤖 Generated with [Claude Code](https://claude.com/claude-code)