### PR TITLE
fix(a11y): include visible text in donate button accessible name (WCAG 2.5.3)

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,7 +44,7 @@
             href="https://opencollective.com/civic-tech-waterloo-region"
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="Support us on Open Collective"
+            aria-label="Donate — Support us on Open Collective"
             ><svg class="btn__icon icon" width="16" height="16">
               <use href="#icon-heart"></use></svg
             >Donate


### PR DESCRIPTION
## Problem

The nav Donate button had a mismatch between its visible text ("Donate") and accessible name ("Support us on Open Collective"). This violates WCAG 2.1 SC 2.5.3 (Label in Name) — voice control users who say "click Donate" can't activate the button because the browser looks for elements whose accessible name contains "Donate", and this one doesn't.

Caught by Lighthouse `label-content-name-mismatch` audit (serious impact, WCAG 2.1 A).

## Fix

```html
<!-- Before -->
aria-label="Support us on Open Collective"

<!-- After -->
aria-label="Donate — Support us on Open Collective"
```

The visible text "Donate" is now included at the start of the accessible name, satisfying WCAG 2.5.3 while preserving the additional context about where the link goes.

## Test plan

- [x] `npm run lint` clean
- [ ] CI green (pa11y should now pass the label-content-name-mismatch check)
- [ ] Lighthouse audit re-run confirms 0 Best Practices failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)