### PR TITLE
ci(security): add workflow_dispatch trigger for manual runs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
   schedule:
     - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 permissions: { }
 


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` to `security.yml` so the Security workflow can be triggered manually from the GitHub Actions UI
- Motivated by today's transient `startup_failure` on the scheduled run (run #608), which GitHub would not allow to be re-run via the normal retry button

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, confirm the "Run workflow" button appears on the Security workflow page in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)