### PR TITLE
fix(ci): downgrade gitleaks-action v3→v2.3.9 to fix startup_failure

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         with:
           log-level: warn
           redact: true


### PR DESCRIPTION
## Problem

The Security workflow has been failing with \`startup_failure\` (no jobs, no logs) on every run since June 8. All other workflows (Lint, Accessibility, CodeQL, Deploy) pass on the same commits.

**Root cause:** \`gitleaks/gitleaks-action@v3.0.0\` declares \`using: "node24"\` in its \`action.yml\`. GitHub Actions validates the \`runs.using\` field at startup — before any job runs — and currently rejects \`"node24"\` as an unsupported runtime value, producing a \`startup_failure\` with zero logs.

## Fix

Downgrade to \`v2.3.9\` (SHA-pinned), which declares \`using: "node20"\`. The existing \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"\` step env var overrides the runtime at execution time, satisfying the June 2 Node.js 20 deprecation requirement while bypassing the startup validation check. This was the working configuration before Dependabot bumped to v3.0.0 in PR #125.

## To do later

Re-upgrade to a \`gitleaks-action\` release that uses \`node24\` once GitHub formally lists \`"node24"\` as a supported action runtime value (and remove \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` at that point).

## Test plan

- [ ] Verify Security CI passes on this PR (specifically the \`Scan for committed secrets\` job)
- [ ] After merge, trigger the Security workflow manually via the "Run workflow" button added in #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)