### PR TITLE
fix(ci): replace gitleaks-action with direct binary install

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,13 +20,9 @@ jobs:
   gitleaks:
     name: Scan for committed secrets
     runs-on: ubuntu-latest
-    # Dependabot PRs run in an isolated context that does not receive org/repo
-    # secrets via the pull_request event. Skip the scan for Dependabot since it
-    # only bumps dependency versions and will not introduce committed secrets.
-    # To also scan Dependabot PRs, add GITLEAKS_LICENSE as a Dependabot secret:
-    # Settings → Secrets and variables → Dependabot → New secret.
-    # Use PR author instead of github.actor: actor changes on manual re-runs,
-    # which would cause the job to run again on a Dependabot PR and fail.
+    # Skip Dependabot PRs — they only bump dependency versions and will not
+    # introduce committed secrets. Use PR author instead of github.actor:
+    # actor changes on manual re-runs, which would re-trigger on Dependabot PRs.
     if: >-
       ${{
         github.event_name != 'pull_request' ||
@@ -40,15 +36,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+            | tar -xz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
-        with:
-          log-level: warn
-          redact: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+        run: gitleaks detect --source . --log-level warn --redact --exit-code 1
 
   npm-audit:
     name: Scan npm dependencies for vulnerabilities


### PR DESCRIPTION
## Problem

\`gitleaks/gitleaks-action\` has been failing with \`startup_failure\` on every Security workflow run since June 8 — producing zero logs regardless of which version is pinned (v2.3.9 or v3.0.0). The failure occurs at GitHub Actions' workflow validation layer before any job runs, making it impossible to diagnose without GitHub-side logs.

## Fix

Replace the action with a direct \`curl\` install of the \`gitleaks\` binary v8.30.1, run via a \`run:\` step:

```yaml
- name: Install Gitleaks
  run: |
    curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
      | tar -xz gitleaks
    sudo mv gitleaks /usr/local/bin/gitleaks

- name: Run Gitleaks
  run: gitleaks detect --source . --log-level warn --redact --exit-code 1
```

**Why this works:** Eliminates the \`gitleaks/gitleaks-action\` reference entirely — no \`action.yml\` to validate, no node runtime check. Failures produce full shell logs instead of opaque startup errors.

**Side effects removed:** \`GITLEAKS_LICENSE\` secret reference and \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` env var are no longer needed.

## Test plan

- [ ] Security workflow starts (no \`startup_failure\`) ← the key signal
- [ ] \`Scan for committed secrets\` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)