### PR TITLE
fix(deps): bump concurrent-ruby 1.3.6 → 1.3.7 (CVE-2026-54904)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
       bundler (>= 1.2.0)
       thor (~> 1.0)
     colorator (1.1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)


### PR DESCRIPTION
## What

Bumps the transitive gem `concurrent-ruby` from **1.3.6 → 1.3.7** in `Gemfile.lock`.

## Why

Trivy (bundled inside the **super-linter** CI job) scans `Gemfile.lock` against a live vulnerability DB and now flags three advisories against `concurrent-ruby 1.3.6`, all fixed in **1.3.7**:

| Vulnerability | Severity | Title |
| ------------- | -------- | ----- |
| CVE-2026-54904 | HIGH | `AtomicReference#update` livelock |
| CVE-2026-54905 | LOW | `ReentrantReadWriteLock` read-count race |
| CVE-2026-54906 | — | `ReadWriteLock` allows wrong-thread write |

These CVEs were published **after** `main`'s Lint workflow last ran (2026-06-08), so `main` is still green but every *open* PR now fails `super-linter` on this finding — even PRs that have nothing to do with it (e.g. #138, a `form-data` JS bump). This change clears the root cause repo-wide.

## Scope / risk

- **Lockfile-only.** `concurrent-ruby` is pulled in transitively via `i18n (~> 1.0)`; the existing `~> 1.0` constraint already permits 1.3.7, so no `Gemfile` change is needed.
- `concurrent-ruby` has no sub-dependencies, so `bundle update concurrent-ruby --conservative` produced a single-line diff with no cascade.
- The required `bundler-audit` check uses a different advisory DB and was already passing; this change keeps it passing.

## Follow-up

Once merged, `@dependabot rebase` on #138 will pull this fix in and turn its `super-linter` check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)