### PR TITLE
fix(deps): bump js-yaml to 4.2.0 and tmp override to 0.2.7 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4237,10 +4237,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4685,29 +4695,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/markdownlint-cli/node_modules/minimatch": {
@@ -7979,9 +7966,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "minimatch@3.1.5": {
       "brace-expansion": "^1.1.14"
     },
-    "tmp": "0.2.6"
+    "tmp": "0.2.7"
   }
 }


### PR DESCRIPTION
## What
Clears the **two remaining open Dependabot npm alerts** on `main`.

| Package | Before | After | Alert |
| ------- | ------ | ----- | ----- |
| `js-yaml` (top-level) | 4.1.1 | 4.2.0 | GHSA-h67p-54hq-rp68 (MEDIUM) |
| `tmp` | 0.2.6 | 0.2.7 | GHSA-7c78-jf6q-g5cm (HIGH) |

## Why these needed manual fixes
- **js-yaml:** #137 bumped `markdownlint-cli`, which only updated the *nested* `node_modules/markdownlint-cli/node_modules/js-yaml`. The vulnerable **top-level hoisted** `node_modules/js-yaml@4.1.1` (used by other tooling) was left behind. `npm update js-yaml` lifts it to 4.2.0 and npm dedupes the copies.
- **tmp:** `package.json` `overrides` pinned `tmp` to exactly `0.2.6` — now the vulnerable version. That pin blocked both `npm update` and Dependabot from bumping it (which is why no Dependabot PR existed). Moving the override to `0.2.7` (compatible with `selenium-webdriver`'s `^0.2.5`) resolves it.

## Scope
Lockfile change plus a single `overrides` line; no direct dependency changes. **Supersedes #140** (which fixed only js-yaml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)