### PR TITLE
fix(deps): bump json gem to 2.21.1 and pin axios to 1.18.0 (security)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.19.5)
+    json (2.21.1)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,9 +1516,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "minimatch@3.1.5": {
       "brace-expansion": "^1.1.14"
     },
-    "tmp": "0.2.7"
+    "tmp": "0.2.7",
+    "axios": "1.18.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `json` gem 2.19.5 → 2.21.1 (lockfile-only, within jekyll's `json (~> 2.6)` constraint) — fixes CVE-2026-54696 (heap buffer overflow when streaming to IO), which was failing the required `Scan Ruby gems for vulnerabilities` check on `main`.
- Pins `axios` to 1.18.0 via a `package.json` override (same pattern as the existing `tmp`/`lodash`/`minimatch` overrides) — fixes GHSA-xj6q-8x83-jv6g (prototype pollution → Basic auth header injection), reported in Dependabot alert #86. axios is a transitive dev dependency via `@axe-core/cli` → `chromedriver`, not used directly.

Closes the alert at https://github.com/CivicTechWR/ctwr-web/security/dependabot/86

## Test plan
- [x] `bundle exec bundler-audit check --update` → `No vulnerabilities found`
- [x] `npm audit` → axios no longer listed
- [x] `npm run lint` → passes
- [x] `npm run test:css:all` → passes
- [x] `npm run test:luma` → passes
- [x] `bundle exec jekyll build` → succeeds
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmSBR5f37WeKuty1Je4rcv