### PR TITLE
fix(deps): bump js-yaml to 4.3.0 and brace-expansion overrides (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1096,9 +1096,9 @@
       }
     },
     "node_modules/@sentry/node/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1741,9 +1741,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4237,9 +4237,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -4675,9 +4675,9 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,9 +59,16 @@
     },
     "lodash": "^4.18.1",
     "minimatch@3.1.5": {
-      "brace-expansion": "^1.1.14"
+      "brace-expansion": "^1.1.16"
+    },
+    "minimatch@9.0.9": {
+      "brace-expansion": "^2.1.2"
+    },
+    "minimatch@10.2.5": {
+      "brace-expansion": "^5.0.7"
     },
     "tmp": "0.2.7",
-    "axios": "1.18.0"
+    "axios": "1.18.0",
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
## Summary
Fixes 4 newly-published Dependabot alerts against packages already in the lockfile (all created 2026-07-21, right after #146 merged):

- **#90** — `js-yaml` 4.2.0 → 4.3.0 (GHSA-52cp-r559-cp3m, quadratic CPU DoS via YAML merge-key chains). `markdownlint-cli` pins js-yaml with `~4.2.0`, which caps below the patched version — added a top-level override to force the bump, same as the existing `tmp`/`axios` overrides.
- **#88** — `brace-expansion` 1.1.14 → 1.1.16 (GHSA-3jxr-9vmj-r5cp) under `minimatch@3.1.5` (clean-css-cli → glob). The *existing* override from a prior CVE fix was itself the vulnerable pin — bumped `^1.1.14` → `^1.1.16`.
- **#89** — `brace-expansion` 2.1.0 → 2.1.2, same GHSA, under `minimatch@9.0.9` (lighthouse → @sentry/node). New scoped override added.
- **#87** — `brace-expansion` 5.0.6 → 5.0.7, same GHSA, under `minimatch@10.2.5` (markdownlint-cli). New scoped override added.

All three `brace-expansion` instances are separate, non-deduped copies because they sit under three different incompatible `minimatch` majors — a single blanket override can't satisfy all three, hence the three scoped entries (matching the existing `minimatch@3.1.5` pattern in this repo).

## Test plan
- [x] `npm ls js-yaml` / `npm ls brace-expansion` → all instances show patched versions, `overridden`
- [x] `npm audit` → none of js-yaml/brace-expansion/axios flagged
- [x] `npm run lint` (exercises markdownlint-cli + js-yaml directly via `lint:md`) → passes
- [x] `npm run test:css:all` → passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmSBR5f37WeKuty1Je4rcv