### PR TITLE
SEO fixes: exclude test fixtures, add og:image and Event schema

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -9,6 +9,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   local community using technology-based solutions.
 baseurl: "" # The subpath of your site, e.g., /blog
 url: "https://civictechwr.org" # The base URL of your site
+image: /images/hacknight-1.jpg # default social preview image (og:image / twitter:image), via jekyll-seo-tag
 
 # Socials
 slack_invite: https://join.slack.com/t/civictechwr/shared_invite/zt-2hk4c93hv-DEIbxR_z1xKj8cZmayVHTw

--- a/_config.yaml
+++ b/_config.yaml
@@ -29,6 +29,7 @@ exclude:
   - "LICENSE.txt"
   - "docs"
   - "scripts"
+  - "tests"
   - "eslint.config.js"
   - ".stylelintrc.json"
   - ".htmlhintrc"

--- a/_includes/meeting-section.html
+++ b/_includes/meeting-section.html
@@ -2,7 +2,32 @@
 mtg.date_formatted | default: "Wednesdays" %} {% assign mtg_time =
 mtg.time_formatted | default: "6:00 PM" %} {% assign mtg_loc =
 mtg.location_short | default: "165 King St W, Kitchener" %} {% assign mtg_url =
-mtg.event_url | default: "https://luma.com/civictechwr" %}
+mtg.event_url | default: "https://luma.com/civictechwr" %} {% assign mtg_name =
+mtg.name | default: "CivicTechWR Hacknight" %}
+{% if mtg.datetime_iso %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    "name": {{ mtg_name | jsonify }},
+    "startDate": {{ mtg.datetime_iso | jsonify }},
+    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": {{ mtg_loc | jsonify }},
+      "address": {{ mtg.location_full | default: mtg_loc | jsonify }}
+    },
+    "organizer": {
+      "@type": "Organization",
+      "name": "Civic Tech Waterloo Region",
+      "url": "https://civictechwr.org"
+    },
+    "url": {{ mtg_url | jsonify }},
+    "image": ["https://civictechwr.org/images/hacknight-1.jpg"]
+  }
+</script>
+{% endif %}
 <section
   class="featured section-padding section-secondary-bg meeting-section-alt"
   id="{{ include.section_id | default: 'section_next_meeting' }}"

--- a/_includes/meeting-section.html
+++ b/_includes/meeting-section.html
@@ -9,14 +9,14 @@ mtg.name | default: "CivicTechWR Hacknight" %}
   {
     "@context": "https://schema.org",
     "@type": "Event",
-    "name": {{ mtg_name | jsonify }},
+    "name": {{ mtg_name | jsonify | replace: "<", "\u003c" }},
     "startDate": {{ mtg.datetime_iso | jsonify }},
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": {{ mtg_loc | jsonify }},
-      "address": {{ mtg.location_full | default: mtg_loc | jsonify }}
+      "name": {{ mtg_loc | jsonify | replace: "<", "\u003c" }},
+      "address": {{ mtg.location_full | default: mtg_loc | jsonify | replace: "<", "\u003c" }}
     },
     "organizer": {
       "@type": "Organization",

--- a/_plugins/fetch_luma_event.rb
+++ b/_plugins/fetch_luma_event.rb
@@ -27,6 +27,7 @@ module CivicTechWR
     class TransientFetchError < StandardError; end
 
     FALLBACK = {
+      "name"           => "CivicTechWR Hacknight",
       "date_formatted" => "Wednesdays",
       "time_formatted" => "5:30 PM",
       "datetime_iso"   => nil,
@@ -198,6 +199,14 @@ module CivicTechWR
       short.empty? ? "165 King St W, Kitchener" : short
     end
 
+    # Full-length counterpart to short_location — same URL-substitution guard,
+    # since Luma hides the address behind an RSVP link the same way here too.
+    def full_location(location)
+      return "165 King St W, Kitchener, ON" if location.to_s.start_with?("https://", "http://")
+
+      location.to_s.empty? ? "165 King St W, Kitchener, ON" : location
+    end
+
     def format_event(event)
       start_utc = event[:start_at].utc
       local     = to_eastern(start_utc)
@@ -208,11 +217,13 @@ module CivicTechWR
       ampm   = local.hour < 12 ? "AM" : "PM"
       minute = format("%02d", local.min)
 
-      location_full  = event[:location]
-      location_short = short_location(location_full)
+      location_full  = full_location(event[:location])
+      location_short = short_location(event[:location])
       event_url      = extract_event_url(event[:description]) || "https://luma.com/civictechwr"
+      name           = event[:summary].empty? ? FALLBACK["name"] : event[:summary]
 
       result = {
+        "name"           => name,
         "date_formatted" => "#{local.strftime('%A, %B')} #{local.day}",
         "time_formatted" => "#{hour}:#{minute} #{ampm}",
         "datetime_iso"   => local.iso8601,

--- a/tests/ruby/luma_event_generator_test.rb
+++ b/tests/ruby/luma_event_generator_test.rb
@@ -64,6 +64,21 @@ assert_equal "165 King St W, Kitchener, ON", full_fallback, "Should return fallb
 full_url = generator.send(:full_location, "https://luma.com/event/evt-abc123")
 assert_equal "165 King St W, Kitchener, ON", full_url, "Should return fallback when Luma substitutes event URL for hidden address"
 
+# --- format_event: name carries through the actual summary, not just FALLBACK's ---
+# Uses a summary deliberately different from FALLBACK["name"] so this test would
+# actually fail if the carry-through silently fell back instead of using the real value.
+distinct_event = {
+  summary:     "Special Guest Speaker Night",
+  start_at:    Time.utc(2099, 4, 1, 21, 30, 0),
+  end_at:      Time.utc(2099, 4, 2, 0, 0, 0),
+  location:    "165 King St W, Kitchener, ON N2G 1A7, Canada",
+  description: "Get up-to-date information at: https://luma.com/testevent",
+  uid:         "evt-distinct-test@events.lu.ma"
+}
+distinct_result = generator.send(:format_event, distinct_event)
+assert_equal "Special Guest Speaker Night", distinct_result["name"],
+  "Should carry the real event summary through, not silently fall back to FALLBACK[\"name\"]"
+
 # --- unescape_ical: backslash-escape sequences ---
 unescaped = generator.send(:unescape_ical, "Kitchener\\, Ontario\\nCanada")
 assert_equal "Kitchener, Ontario\nCanada", unescaped, "Should unescape iCal text escapes"
@@ -80,6 +95,8 @@ assert_equal "CivicTechWR Hacknight", result["name"],
   "Should carry the event summary through as the Event schema name"
 assert_equal "165 King St W, Kitchener", result["location_short"],
   "Should format the expected short location"
+assert_equal "165 King St W, Kitchener, ON N2G 1A7, Canada", result["location_full"],
+  "Should pass through the full location when it's a real address, not a Luma RSVP URL"
 assert_equal "https://luma.com/m9qpiym3", result["event_url"],
   "Should extract and format the RSVP URL from event description"
 assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\z/, result["datetime_iso"],

--- a/tests/ruby/luma_event_generator_test.rb
+++ b/tests/ruby/luma_event_generator_test.rb
@@ -54,6 +54,16 @@ assert_equal "165 King St W, Kitchener", short_fallback, "Should return fallback
 short_url = generator.send(:short_location, "https://luma.com/event/evt-abc123")
 assert_equal "165 King St W, Kitchener", short_url, "Should return fallback when Luma substitutes event URL for hidden address"
 
+# --- full_location ---
+full = generator.send(:full_location, "165 King St W, Kitchener, ON N2G 1A7, Canada")
+assert_equal "165 King St W, Kitchener, ON N2G 1A7, Canada", full, "Should preserve the full location string as-is"
+
+full_fallback = generator.send(:full_location, "")
+assert_equal "165 King St W, Kitchener, ON", full_fallback, "Should return fallback when location is empty"
+
+full_url = generator.send(:full_location, "https://luma.com/event/evt-abc123")
+assert_equal "165 King St W, Kitchener, ON", full_url, "Should return fallback when Luma substitutes event URL for hidden address"
+
 # --- unescape_ical: backslash-escape sequences ---
 unescaped = generator.send(:unescape_ical, "Kitchener\\, Ontario\\nCanada")
 assert_equal "Kitchener, Ontario\nCanada", unescaped, "Should unescape iCal text escapes"
@@ -66,6 +76,8 @@ end
 
 result = stub_generator.send(:fetch_next_event)
 assert_equal true, result["found"], "Should return found=true for future events"
+assert_equal "CivicTechWR Hacknight", result["name"],
+  "Should carry the event summary through as the Event schema name"
 assert_equal "165 King St W, Kitchener", result["location_short"],
   "Should format the expected short location"
 assert_equal "https://luma.com/m9qpiym3", result["event_url"],
@@ -84,6 +96,8 @@ assert_equal false, past_result["found"],
   "fetch_next_event should return FALLBACK when all events are in the past"
 assert_equal "https://luma.com/civictechwr", past_result["event_url"],
   "FALLBACK event_url should be the generic calendar URL"
+assert_equal "CivicTechWR Hacknight", past_result["name"],
+  "FALLBACK name should still be usable as an Event schema name"
 
 # --- parse_ical_events: RFC 5545 line unfolding ---
 folded_ical = <<~ICAL


### PR DESCRIPTION
## Summary

Follow-up from this session's site audit (SEO grade: B), three fixes:

- **Excludes `tests/` from the Jekyll build.** Test fixtures under `tests/fixtures/luma/*.html` — including one literally named `broken_next_data_calendar.html` — were being built, served live, and picked up by `jekyll-sitemap` into `sitemap.xml`. This was a real production leak, not hypothetical.
- **Sets a default `og:image`** (`images/hacknight-1.jpg`) so social shares get a preview image via `jekyll-seo-tag`, which previously had none configured.
- **Adds schema.org `Event` JSON-LD** for the recurring hacknight, sourced live from `site.data.next_meeting` (populated at build time by `_plugins/fetch_luma_event.rb` from the real Luma calendar feed) rather than a hardcoded date/time that would drift out of sync.

## Bug found and fixed along the way

Wiring the Event schema's `address` field to `location_full` surfaced a real bug: that field had no guard against Luma substituting an RSVP URL for the address when it's hidden pending RSVP (`short_location` already handled exactly this case; `location_full` never did, because nothing rendered it before this feature). Added `full_location` mirroring `short_location`'s guard, with matching test coverage.

## Review

Went through an independent whole-branch review (opus-tier) before opening this PR. Two Minor findings were folded in:
- `jsonify` alone doesn't escape `</script>`-breaking characters (`<`) — added explicit escaping on every free-text field interpolated into the JSON-LD block. Low real-world risk (first-party data, CSP blocks inline script execution regardless) but cheap defense-in-depth.
- The original "name carries through" test used a fixture whose summary happened to be identical to the fallback value, so it couldn't actually fail if the carry-through broke. Added an isolated test case with a distinct name, plus a missing `location_full` integration assertion.

## Test plan

- [x] `bundle exec jekyll build` (clean, cache cleared) — confirmed `_site/tests/` absent, Event JSON-LD present and valid on `index.html`, `address` field correctly shows a real address not a Luma URL
- [x] `bundle exec ruby tests/ruby/luma_event_generator_test.rb` — all pass, including new `full_location` and name-carry-through cases
- [x] `npm run test` (CSS component/asset/budget + Luma) — pass
- [x] `npm run lint` (css/md/yaml/json/shell/csp) — pass
- [x] `npx htmlhint --config .htmlhintrc _includes/meeting-section.html` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmVDzx5KGck4SRwXsyU31w