### PR TITLE
fix(security): replace safeUrl()'s prefix allowlist with URL()-based validation

### DIFF
--- a/js/projects.js
+++ b/js/projects.js
@@ -4,19 +4,25 @@
     // ── helpers ──────────────────────────────────────────────────────────────
     function safeUrl(url) {
       if (!url) return "#";
-      // Browsers normalize embedded backslashes and tab/newline/CR characters
-      // during URL parsing (WHATWG URL spec), which can turn a seemingly-safe
-      // relative path (e.g. "/\evil.com" or "/\t/evil.com") into a
-      // protocol-relative reference to an attacker-controlled host.
-      if (/[\t\n\r\\]/.test(url)) return "#";
-      // Protocol-relative URLs ("//evil.com") start with "/" too but resolve
-      // to an attacker-controlled host using the current page's scheme —
-      // must be excluded from the relative-path allowance below.
-      return url.startsWith("https://") ||
-        url.startsWith("http://") ||
-        (url.startsWith("/") && !url.startsWith("//"))
-        ? url
-        : "#";
+      // Let the platform's own URL parser do the normalization instead of
+      // guessing at bypass characters one at a time (see issue #151):
+      // browsers resolve things like "//evil.com" or "/\evil.com" to an
+      // off-origin host in ways that are easy to miss with string prefixes.
+      const base =
+        (typeof window !== "undefined" && window.location && window.location.href) ||
+        "https://civictechwr.org/";
+      let resolved;
+      try {
+        resolved = new URL(url, base);
+      } catch (e) {
+        return "#";
+      }
+      if (resolved.protocol !== "https:" && resolved.protocol !== "http:") return "#";
+      // Absolute http(s) URLs may point anywhere (e.g. project.github linking
+      // to github.com). Anything else must resolve to this site's own origin.
+      const isAbsoluteHttpInput = /^https?:\/\//i.test(url);
+      if (!isAbsoluteHttpInput && resolved.origin !== new URL(base).origin) return "#";
+      return url;
     }
 
     function formatTag(tag) {

--- a/tests/js/safe-url.js
+++ b/tests/js/safe-url.js
@@ -13,6 +13,8 @@ assert.strictEqual(safeUrl('/\r/evil.com'), '#', 'Should reject paths with an em
 assert.strictEqual(safeUrl(''), '#', 'Should return # for empty input');
 assert.strictEqual(safeUrl(undefined), '#', 'Should return # for undefined input');
 assert.strictEqual(safeUrl(null), '#', 'Should return # for null input');
+assert.strictEqual(safeUrl('vbscript:alert(1)'), '#', 'Should reject vbscript: URLs');
+assert.strictEqual(safeUrl('mailto:someone@example.com'), '#', 'Should reject mailto: URLs (not http/https)');
 
 assert.strictEqual(
   safeUrl('https://github.com/CivicTechWR/ctwr-web'),
@@ -25,9 +27,27 @@ assert.strictEqual(
   'Should pass through http:// URLs unchanged'
 );
 assert.strictEqual(
+  safeUrl('HTTPS://github.com/CivicTechWR/ctwr-web'),
+  'HTTPS://github.com/CivicTechWR/ctwr-web',
+  'Should pass through uppercase-scheme https URLs unchanged'
+);
+assert.strictEqual(
   safeUrl('/images/logo.png'),
   '/images/logo.png',
   'Should pass through relative paths unchanged'
+);
+assert.strictEqual(
+  safeUrl('images/logo.png'),
+  'images/logo.png',
+  'Should pass through relative paths without a leading slash (resolves same-origin)'
+);
+// "https:evil.com" has no "//" after the scheme, so the URL parser treats it
+// as a same-scheme relative reference against the base rather than a new
+// authority — it resolves to a same-origin path, not to evil.com.
+assert.strictEqual(
+  safeUrl('https:evil.com'),
+  'https:evil.com',
+  'Scheme-without-slashes input should resolve same-origin, not to an external host'
 );
 
 console.log('safeUrl() sanitizer tests passed.');


### PR DESCRIPTION
## Summary
- Closes #151: replaces `safeUrl()`'s `startsWith`-based prefix allowlist in `js/projects.js` with `new URL(url, base)`-based validation.
- The old approach went through two rounds of real bypasses in #148 (protocol-relative `//evil.com`, then backslash/tab/newline/CR normalization tricks like `/\evil.com`) because prefix matching can't account for how browsers actually normalize a URL string before resolving it — each fix was reactive to one specific bypass character.
- New logic: reject anything that doesn't resolve to `http:`/`https:`; for inputs that aren't themselves an absolute `http(s)://` URL, additionally require the resolved origin to match the page's own origin. This lets the platform's own parser do the normalization instead of enumerating bypass characters.

## Verification
- Standalone Node script (same WHATWG `URL` algorithm browsers implement) against ~25 payloads, including all previously-fixed bypasses plus new ones: userinfo tricks (`https://evil.com@civictechwr.org/`), scheme-without-slashes (`https:evil.com` — confirmed resolves same-origin, not to an external host), tab-split schemes (`ht\ttp://evil.com`).
- Independent `ecc:security-reviewer` pass, confirmed safe (9/10 confidence) — read the actual call sites (`buildFeaturedCard`'s `project.github`/`project.url`/`project.logo` → `<a href>`/`<img src>` as DOM property assignments, no attribute-breakout vector) and found no exploitable bypass. One residual scope note (not a defect): `safeUrl` still allows absolute `https://` URLs to point at any external host by design — that's pre-existing, intentional behavior for external project links, unchanged by this refactor.
- `tests/js/safe-url.js` expanded to cover the new implementation's behavior (uppercase scheme, `vbscript:`/`mailto:` rejection, the scheme-without-slashes case, and a bare relative path without a leading slash — a deliberate widening since it still resolves same-origin).

## Test plan
- [x] `npm run test:js` — all safeUrl() cases pass
- [x] `npm run test` — full suite passes
- [x] `npm run lint` — all linters pass
- [x] Standalone Node verification against ~25 URL payloads before and after the review pass
- [x] Independent security review of the call sites and origin-check logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmVDzx5KGck4SRwXsyU31w