### PR TITLE
fix(seo): replace generic page titles on about.html and projects.html

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: About Us
+title: Our Mission & Community
 permalink: /about.html
 description: "Learn about CivicTech Waterloo Region — our team, mission, and the community of designers, technologists, and civic leaders working on local challenges in the KW area."
 preload_image: "images/about-us.webp"

--- a/projects.html
+++ b/projects.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Projects
+title: Civic Tech Projects We've Built
 permalink: /projects.html
 description: "Explore civic technology projects built by the CivicTechWR community to improve life across Waterloo Region — from civic engagement tools to open data resources."
 preload_fetch: "js/projects.json"


### PR DESCRIPTION
## Summary
- Real Google Search Console data (first pull after GSC verification, 28-day window) shows `about.html` and `projects.html` rank well (avg. position 6.9 and 4.7 — `projects.html` is near the top of page 1) but convert at only ~1% CTR, versus 15.8% on the homepage.
- Not a ranking problem: the rendered `<title>` was `About Us | Civic Tech Waterloo Region` and `Projects | Civic Tech Waterloo Region` — generic enough that a non-branded searcher has no reason to pick this result over any other org's identically-titled page.
- Renamed to `Our Mission & Community` and `Civic Tech Projects We've Built`. Verified rendered output via a real Jekyll build: `52` and `60` characters including the site-name suffix, both under the ~60-char safe SERP display width (no truncation risk).
- No description/copy changes beyond the `title` front-matter field — small, low-risk, easily reversible if the wording doesn't land.

## Test plan
- [x] `bundle exec jekyll build` — confirmed rendered `<title>` output for both pages
- [x] Grepped `tests/` for any spec hardcoding the old title strings — none found
- [x] `npm run test` — full suite passes
- [x] `npm run lint` — all linters pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmVDzx5KGck4SRwXsyU31w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the About page title to “Our Mission & Community.”
  * Updated the Projects page title to “Civic Tech Projects We've Built.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->