### PR TITLE
fix(perf): add explicit width/height to hero images, no-op Mailchimp script error

### DIFF
--- a/_includes/meeting-section.html
+++ b/_includes/meeting-section.html
@@ -42,6 +42,8 @@ mtg.name | default: "CivicTechWR Hacknight" %}
             src="/images/hacknight-8.jpg"
             class="about-image img-fluid"
             alt="CivicTech Waterloo Region community members at weekly hacknight gathering"
+            width="1600"
+            height="1200"
             loading="lazy"
             decoding="async"
           />

--- a/about.html
+++ b/about.html
@@ -127,6 +127,8 @@ preload_image: "images/about-us.webp"
             class="about-image img-fluid"
             src="/images/about-us.jpg"
             alt="CivicTech Waterloo Region organizing team and community members at a group gathering"
+            width="1600"
+            height="1200"
             loading="lazy"
             decoding="async"
           />

--- a/index.html
+++ b/index.html
@@ -138,6 +138,8 @@ description: "CivicTechWR brings together people from different sectors to work 
                   src="/images/hacknight-1.jpg"
                   class="about-image img-fluid"
                   alt="CivicTech Waterloo Region community members collaborating at weekly hacknight event"
+                  width="1600"
+                  height="1200"
                   loading="lazy"
                   decoding="async"
                 />
@@ -177,6 +179,8 @@ description: "CivicTechWR brings together people from different sectors to work 
                   src="/images/hacknight-7.jpg"
                   class="about-image img-fluid"
                   alt="CivicTech Waterloo Region community members working together at hacknight event"
+                  width="1600"
+                  height="1200"
                   loading="lazy"
                   decoding="async"
                 />

--- a/js/mailchimp-embed.js
+++ b/js/mailchimp-embed.js
@@ -4,6 +4,7 @@
   if (!p || !p.parentNode) return;
   m.async = 1;
   m.src = i;
+  m.onerror = function () {};
   p.parentNode.insertBefore(m, p);
 })(
   document,


### PR DESCRIPTION
## Summary
- Adds `width="1600" height="1200"` to the four hero/hacknight `<img>` tags (`index.html` ×2, `about.html` ×1, `_includes/meeting-section.html` ×1) so the browser can reserve the correct aspect-ratio box before the image loads, fixing the 0.087 CLS regression measured on about.html under Lighthouse throttling. All four source images are confirmed 1600×1200 (4:3) on disk via `sips`, and render through `.img-fluid`'s `height:auto`, so no distortion.
- Adds a no-op `onerror` handler to the dynamically-injected Mailchimp connected-site `<script>` tag in `js/mailchimp-embed.js`, silencing a hard console error (and associated Best Practices point loss in Lighthouse) when chimpstatic.com is blocked by an ad blocker or restrictive network policy.

Scoped from #159. Responsive `srcset`/`sizes` for these images (also flagged in the audit) is left for a follow-up since it requires generating resized image assets — not done here to keep this PR focused.

## Test plan
- [x] `bundle exec jekyll build` — clean build, confirmed `width`/`height` render correctly in `_site/index.html` and `_site/about.html`
- [x] `npm run lint` — all lint stages pass (CSS, md, yaml, json, shell, CSP)
- [x] `npm test` — CSS asset-integrity, CSS budget, Luma event generator, and `safeUrl()` unit tests all pass
- [x] `npm run test:e2e` — all 84 Playwright tests pass against the fresh build
- [x] Independent code-review pass (9.5/10 confidence) — verified image dimensions on both JPG and WebP paths, confirmed no CSS rule sets a conflicting fixed height, confirmed the Mailchimp `onerror` doesn't swallow anything load-bearing

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmVDzx5KGck4SRwXsyU31w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading behavior by adding explicit dimensions to featured, team, About, and Hacknights images.
  * Added basic error handling for the newsletter signup embed script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->