### PR TITLE
fix(seo): add offers, performer, description, endDate to Event JSON-LD

### DIFF
--- a/_includes/meeting-section.html
+++ b/_includes/meeting-section.html
@@ -11,7 +11,8 @@ mtg.name | default: "CivicTechWR Hacknight" %}
     "@type": "Event",
     "name": {{ mtg_name | jsonify | replace: "<", "\u003c" }},
     "startDate": {{ mtg.datetime_iso | jsonify }},
-    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+    {% if mtg.datetime_iso_end %}"endDate": {{ mtg.datetime_iso_end | jsonify }},
+    {% endif %}"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
@@ -23,6 +24,19 @@ mtg.name | default: "CivicTechWR Hacknight" %}
       "name": "Civic Tech Waterloo Region",
       "url": "https://civictechwr.org"
     },
+    "performer": {
+      "@type": "Organization",
+      "name": "Civic Tech Waterloo Region",
+      "url": "https://civictechwr.org"
+    },
+    "offers": {
+      "@type": "Offer",
+      "url": {{ mtg_url | jsonify }},
+      "price": "0",
+      "priceCurrency": "CAD",
+      "availability": "https://schema.org/InStock"
+    },
+    "description": "Join Civic Tech Waterloo Region for a free, weekly hacknight — a drop-in gathering where community members, designers, and technologists collaborate on local civic tech projects. Everyone is welcome, no tech skills required.",
     "url": {{ mtg_url | jsonify }},
     "image": ["https://civictechwr.org/images/hacknight-1.jpg"]
   }

--- a/_plugins/fetch_luma_event.rb
+++ b/_plugins/fetch_luma_event.rb
@@ -183,15 +183,20 @@ module CivicTechWR
     end
 
     # Time.utc silently normalizes an out-of-range day (e.g. Feb 30 -> Mar 2)
-    # instead of raising, unlike month/hour/minute/second which do raise
-    # ArgumentError. Compare the constructed Time's components back against the
-    # parsed input so a corrupted day is rejected (nil) rather than silently
-    # becoming a different, valid-looking date.
+    # instead of raising, unlike month/hour/minute which do raise ArgumentError.
+    # Compare the constructed Time's components back against the parsed input
+    # so a corrupted day is rejected (nil) rather than silently becoming a
+    # different, valid-looking date.
     def build_validated_utc(year_s, month_s, day_s, hour_s, min_s, sec_s)
       year, month, day, hour, min, sec = [year_s, month_s, day_s, hour_s, min_s, sec_s].map(&:to_i)
-      t = Time.utc(year, month, day, hour, min, sec)
+      # RFC 5545 allows :60 to represent a leap second, but Time.utc(..., 60)
+      # rolls over to the next minute rather than preserving it -- clamp to :59
+      # (the RFC's own fallback for systems without leap-second support) before
+      # validating, so a legitimate leap-second timestamp isn't rejected as nil.
+      validated_sec = sec == 60 ? 59 : sec
+      t = Time.utc(year, month, day, hour, min, validated_sec)
       return nil unless t.year == year && t.month == month && t.day == day &&
-                        t.hour == hour && t.min == min && t.sec == sec
+                        t.hour == hour && t.min == min && t.sec == validated_sec
 
       t
     end
@@ -231,7 +236,10 @@ module CivicTechWR
     def format_event(event)
       start_utc = event[:start_at].utc
       local     = to_eastern(start_utc)
-      local_end = event[:end_at] ? to_eastern(event[:end_at].utc) : nil
+      # RFC 5545 requires DTEND to be strictly after DTSTART; omit an end time
+      # that isn't (rather than publishing an illogical endDate <= startDate
+      # in the site's Event JSON-LD) instead of trusting the feed blindly.
+      local_end = (event[:end_at] && event[:end_at] > event[:start_at]) ? to_eastern(event[:end_at].utc) : nil
 
       # Format time without leading zero, cross-platform
       hour   = local.hour % 12

--- a/_plugins/fetch_luma_event.rb
+++ b/_plugins/fetch_luma_event.rb
@@ -27,14 +27,15 @@ module CivicTechWR
     class TransientFetchError < StandardError; end
 
     FALLBACK = {
-      "name"           => "CivicTechWR Hacknight",
-      "date_formatted" => "Wednesdays",
-      "time_formatted" => "5:30 PM",
-      "datetime_iso"   => nil,
-      "location_short" => "165 King St W, Kitchener",
-      "location_full"  => "165 King St W, Kitchener, ON",
-      "event_url"      => "https://luma.com/civictechwr",
-      "found"          => false
+      "name"             => "CivicTechWR Hacknight",
+      "date_formatted"   => "Wednesdays",
+      "time_formatted"   => "5:30 PM",
+      "datetime_iso"     => nil,
+      "datetime_iso_end" => nil,
+      "location_short"   => "165 King St W, Kitchener",
+      "location_full"    => "165 King St W, Kitchener, ON",
+      "event_url"        => "https://luma.com/civictechwr",
+      "found"            => false
     }.freeze
 
     def generate(site)
@@ -210,6 +211,7 @@ module CivicTechWR
     def format_event(event)
       start_utc = event[:start_at].utc
       local     = to_eastern(start_utc)
+      local_end = event[:end_at] ? to_eastern(event[:end_at].utc) : nil
 
       # Format time without leading zero, cross-platform
       hour   = local.hour % 12
@@ -223,14 +225,15 @@ module CivicTechWR
       name           = event[:summary].empty? ? FALLBACK["name"] : event[:summary]
 
       result = {
-        "name"           => name,
-        "date_formatted" => "#{local.strftime('%A, %B')} #{local.day}",
-        "time_formatted" => "#{hour}:#{minute} #{ampm}",
-        "datetime_iso"   => local.iso8601,
-        "location_short" => location_short,
-        "location_full"  => location_full,
-        "event_url"      => event_url,
-        "found"          => true
+        "name"             => name,
+        "date_formatted"   => "#{local.strftime('%A, %B')} #{local.day}",
+        "time_formatted"   => "#{hour}:#{minute} #{ampm}",
+        "datetime_iso"     => local.iso8601,
+        "datetime_iso_end" => local_end&.iso8601,
+        "location_short"   => location_short,
+        "location_full"    => location_full,
+        "event_url"        => event_url,
+        "found"            => true
       }
 
       Jekyll.logger.info "LumaEvents:",

--- a/_plugins/fetch_luma_event.rb
+++ b/_plugins/fetch_luma_event.rb
@@ -163,22 +163,37 @@ module CivicTechWR
 
     # Parse iCal datetime strings: YYYYMMDDTHHMMSSZ or YYYYMMDDTHHMMSS or YYYYMMDD
     # Always returns UTC to avoid dependence on the build machine's local timezone.
-    # Returns nil (rather than raising) for syntactically-matched but out-of-range
-    # components (e.g. month 13) so one malformed DTSTART/DTEND in the feed just
-    # drops that field/event instead of aborting the whole fetch to FALLBACK.
+    # Returns nil (rather than raising, or silently normalizing) for out-of-range
+    # components (e.g. month 13, or day 30 in February) so one malformed
+    # DTSTART/DTEND in the feed just drops that field/event instead of aborting
+    # the whole fetch to FALLBACK or displaying a silently-shifted wrong date.
     def parse_ical_dt(dt_str)
       return nil if dt_str.to_s.strip.empty?
 
       s = dt_str.strip
       if (m = s.match(/\A(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z\z/))
-        Time.utc(m[1].to_i, m[2].to_i, m[3].to_i, m[4].to_i, m[5].to_i, m[6].to_i)
+        build_validated_utc(m[1], m[2], m[3], m[4], m[5], m[6])
       elsif (m = s.match(/\A(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\z/))
-        Time.utc(m[1].to_i, m[2].to_i, m[3].to_i, m[4].to_i, m[5].to_i, m[6].to_i)
+        build_validated_utc(m[1], m[2], m[3], m[4], m[5], m[6])
       elsif (m = s.match(/\A(\d{4})(\d{2})(\d{2})\z/))
-        Time.utc(m[1].to_i, m[2].to_i, m[3].to_i)
+        build_validated_utc(m[1], m[2], m[3], "0", "0", "0")
       end
     rescue ArgumentError
       nil
+    end
+
+    # Time.utc silently normalizes an out-of-range day (e.g. Feb 30 -> Mar 2)
+    # instead of raising, unlike month/hour/minute/second which do raise
+    # ArgumentError. Compare the constructed Time's components back against the
+    # parsed input so a corrupted day is rejected (nil) rather than silently
+    # becoming a different, valid-looking date.
+    def build_validated_utc(year_s, month_s, day_s, hour_s, min_s, sec_s)
+      year, month, day, hour, min, sec = [year_s, month_s, day_s, hour_s, min_s, sec_s].map(&:to_i)
+      t = Time.utc(year, month, day, hour, min, sec)
+      return nil unless t.year == year && t.month == month && t.day == day &&
+                        t.hour == hour && t.min == min && t.sec == sec
+
+      t
     end
 
     # Unescape iCal text-value escapes per RFC 5545:

--- a/_plugins/fetch_luma_event.rb
+++ b/_plugins/fetch_luma_event.rb
@@ -163,6 +163,9 @@ module CivicTechWR
 
     # Parse iCal datetime strings: YYYYMMDDTHHMMSSZ or YYYYMMDDTHHMMSS or YYYYMMDD
     # Always returns UTC to avoid dependence on the build machine's local timezone.
+    # Returns nil (rather than raising) for syntactically-matched but out-of-range
+    # components (e.g. month 13) so one malformed DTSTART/DTEND in the feed just
+    # drops that field/event instead of aborting the whole fetch to FALLBACK.
     def parse_ical_dt(dt_str)
       return nil if dt_str.to_s.strip.empty?
 
@@ -174,6 +177,8 @@ module CivicTechWR
       elsif (m = s.match(/\A(\d{4})(\d{2})(\d{2})\z/))
         Time.utc(m[1].to_i, m[2].to_i, m[3].to_i)
       end
+    rescue ArgumentError
+      nil
     end
 
     # Unescape iCal text-value escapes per RFC 5545:

--- a/tests/ruby/luma_event_generator_test.rb
+++ b/tests/ruby/luma_event_generator_test.rb
@@ -87,6 +87,19 @@ no_end_result = generator.send(:format_event, no_end_event)
 assert_equal nil, no_end_result["datetime_iso_end"],
   "datetime_iso_end should be nil (not raise) when the source iCal event has no DTEND"
 
+# --- format_event: datetime_iso_end is nil when DTEND is at or before DTSTART ---
+# RFC 5545 requires DTEND to be strictly after DTSTART; a feed bug shouldn't
+# publish an illogical endDate <= startDate in the site's Event JSON-LD.
+equal_end_event = distinct_event.merge(end_at: distinct_event[:start_at])
+equal_end_result = generator.send(:format_event, equal_end_event)
+assert_equal nil, equal_end_result["datetime_iso_end"],
+  "datetime_iso_end should be nil when DTEND equals DTSTART"
+
+before_end_event = distinct_event.merge(end_at: distinct_event[:start_at] - 3600)
+before_end_result = generator.send(:format_event, before_end_event)
+assert_equal nil, before_end_result["datetime_iso_end"],
+  "datetime_iso_end should be nil when DTEND is before DTSTART"
+
 # --- parse_ical_dt: malformed but syntactically-matched date components return nil, not raise ---
 # Month 13 reliably raises ArgumentError from Time.utc.
 malformed_month = generator.send(:parse_ical_dt, "20991301T000000Z")
@@ -98,6 +111,14 @@ assert_equal nil, malformed_month, "parse_ical_dt should return nil (not raise A
 malformed_day = generator.send(:parse_ical_dt, "20990230T000000Z")
 assert_equal nil, malformed_day,
   "parse_ical_dt should return nil for an overflowing day instead of silently normalizing to a different date"
+
+# --- parse_ical_dt: a leap second (:60) is preserved (clamped to :59), not rejected as invalid ---
+# Time.utc(..., 60) rolls over to the next minute rather than raising or preserving
+# :60, which would otherwise make the round-trip validation reject a legitimate
+# RFC 5545 leap-second timestamp as if it were malformed.
+leap_second = generator.send(:parse_ical_dt, "20161231T235960Z")
+assert_equal true, leap_second.is_a?(Time), "parse_ical_dt should not reject a leap-second (:60) timestamp"
+assert_equal 59, leap_second.sec, "A :60 leap second should be clamped to :59 per the RFC's no-leap-second-support fallback"
 
 # --- parse_ical_events: a malformed DTSTART is skipped rather than crashing the whole feed ---
 malformed_ical = <<~ICAL

--- a/tests/ruby/luma_event_generator_test.rb
+++ b/tests/ruby/luma_event_generator_test.rb
@@ -88,10 +88,16 @@ assert_equal nil, no_end_result["datetime_iso_end"],
   "datetime_iso_end should be nil (not raise) when the source iCal event has no DTEND"
 
 # --- parse_ical_dt: malformed but syntactically-matched date components return nil, not raise ---
-# Month 13 reliably raises ArgumentError from Time.utc (unlike an overflowing day,
-# e.g. Feb 30, which Ruby silently normalizes into March rather than rejecting).
+# Month 13 reliably raises ArgumentError from Time.utc.
 malformed_month = generator.send(:parse_ical_dt, "20991301T000000Z")
 assert_equal nil, malformed_month, "parse_ical_dt should return nil (not raise ArgumentError) for out-of-range date components"
+
+# --- parse_ical_dt: an overflowing day (Feb 30) must not silently normalize into March ---
+# Time.utc(2099, 2, 30, ...) does NOT raise -- it silently rolls over to March 2.
+# parse_ical_dt must catch this via component comparison, not just rescue ArgumentError.
+malformed_day = generator.send(:parse_ical_dt, "20990230T000000Z")
+assert_equal nil, malformed_day,
+  "parse_ical_dt should return nil for an overflowing day instead of silently normalizing to a different date"
 
 # --- parse_ical_events: a malformed DTSTART is skipped rather than crashing the whole feed ---
 malformed_ical = <<~ICAL

--- a/tests/ruby/luma_event_generator_test.rb
+++ b/tests/ruby/luma_event_generator_test.rb
@@ -78,6 +78,14 @@ distinct_event = {
 distinct_result = generator.send(:format_event, distinct_event)
 assert_equal "Special Guest Speaker Night", distinct_result["name"],
   "Should carry the real event summary through, not silently fall back to FALLBACK[\"name\"]"
+assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\z/, distinct_result["datetime_iso_end"],
+  "datetime_iso_end should be an ISO8601 string with UTC offset when the source event has an end time")
+
+# --- format_event: datetime_iso_end is nil when the source event has no end_at ---
+no_end_event = distinct_event.merge(end_at: nil)
+no_end_result = generator.send(:format_event, no_end_event)
+assert_equal nil, no_end_result["datetime_iso_end"],
+  "datetime_iso_end should be nil (not raise) when the source iCal event has no DTEND"
 
 # --- unescape_ical: backslash-escape sequences ---
 unescaped = generator.send(:unescape_ical, "Kitchener\\, Ontario\\nCanada")
@@ -101,6 +109,8 @@ assert_equal "https://luma.com/m9qpiym3", result["event_url"],
   "Should extract and format the RSVP URL from event description"
 assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\z/, result["datetime_iso"],
   "datetime_iso should be an ISO8601 string with UTC offset")
+assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\z/, result["datetime_iso_end"],
+  "datetime_iso_end should be an ISO8601 string with UTC offset (fixture event has a DTEND)")
 
 # --- fetch_next_event: stub with all past events → FALLBACK ---
 past_generator = CivicTechWR::LumaEventGenerator.new

--- a/tests/ruby/luma_event_generator_test.rb
+++ b/tests/ruby/luma_event_generator_test.rb
@@ -78,14 +78,48 @@ distinct_event = {
 distinct_result = generator.send(:format_event, distinct_event)
 assert_equal "Special Guest Speaker Night", distinct_result["name"],
   "Should carry the real event summary through, not silently fall back to FALLBACK[\"name\"]"
-assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\z/, distinct_result["datetime_iso_end"],
-  "datetime_iso_end should be an ISO8601 string with UTC offset when the source event has an end time")
+assert_equal "2099-04-01T20:00:00-04:00", distinct_result["datetime_iso_end"],
+  "datetime_iso_end should be the exact Eastern-converted timestamp, not just ISO8601-shaped"
 
 # --- format_event: datetime_iso_end is nil when the source event has no end_at ---
 no_end_event = distinct_event.merge(end_at: nil)
 no_end_result = generator.send(:format_event, no_end_event)
 assert_equal nil, no_end_result["datetime_iso_end"],
   "datetime_iso_end should be nil (not raise) when the source iCal event has no DTEND"
+
+# --- parse_ical_dt: malformed but syntactically-matched date components return nil, not raise ---
+# Month 13 reliably raises ArgumentError from Time.utc (unlike an overflowing day,
+# e.g. Feb 30, which Ruby silently normalizes into March rather than rejecting).
+malformed_month = generator.send(:parse_ical_dt, "20991301T000000Z")
+assert_equal nil, malformed_month, "parse_ical_dt should return nil (not raise ArgumentError) for out-of-range date components"
+
+# --- parse_ical_events: a malformed DTSTART is skipped rather than crashing the whole feed ---
+malformed_ical = <<~ICAL
+  BEGIN:VCALENDAR
+  VERSION:2.0
+  BEGIN:VEVENT
+  DTSTART:20991301T000000Z
+  UID:evt-malformed@events.lu.ma
+  SUMMARY:Malformed Date Event
+  END:VEVENT
+  BEGIN:VEVENT
+  DTSTART:20990415T213000Z
+  DTEND:20990416T000000Z
+  UID:evt-valid@events.lu.ma
+  SUMMARY:Valid Event After Malformed One
+  END:VEVENT
+  END:VCALENDAR
+ICAL
+malformed_events = generator.send(:parse_ical_events, malformed_ical)
+assert_equal 2, malformed_events.length,
+  "Should still parse both events structurally (only the date field itself becomes nil)"
+assert_equal nil, malformed_events.first[:start_at],
+  "Malformed DTSTART should parse to nil rather than raising"
+malformed_generator = CivicTechWR::LumaEventGenerator.new
+malformed_generator.define_singleton_method(:fetch_ical) { |_url| malformed_ical }
+malformed_result = malformed_generator.send(:fetch_next_event)
+assert_equal "Valid Event After Malformed One", malformed_result["name"],
+  "Should skip the event with a malformed DTSTART and still surface the next valid event, rather than crashing to FALLBACK"
 
 # --- unescape_ical: backslash-escape sequences ---
 unescaped = generator.send(:unescape_ical, "Kitchener\\, Ontario\\nCanada")


### PR DESCRIPTION
## Summary
Google Search Console flagged 4 non-critical missing fields on the site's Event structured data (added in an earlier PR): `offers`, `performer`, `description`, `endDate`.

- **`endDate`**: the Luma iCal `DTEND` was already being parsed into `event[:end_at]` by `build_event`, but `format_event` never surfaced it. Added `datetime_iso_end` (same DST-aware `to_eastern` conversion as the existing start time), rendered conditionally in the template so a malformed/missing `DTEND` omits the key rather than emitting `null`.
- **`performer`**: hacknights are informal community meetups with no distinct individual performer, so it reuses the same Organization as `organizer` — schema.org's `Event.performer` accepts `Person` or `Organization`, and this is common practice for recurring community events.
- **`offers`**: hacknights are free and RSVP-only via the existing Luma link, so this is a `$0` Offer pointing at the same URL already used as the JSON-LD's top-level `url`.
- **`description`**: a static sentence describing what a hacknight actually is, since the raw Luma iCal `DESCRIPTION` field is low-value boilerplate (mostly just repeating the RSVP link and address already present elsewhere in the schema).

## Test plan
- [x] `bundle exec jekyll build` — then parsed the built Event JSON-LD with `json.loads` to confirm valid JSON with all 4 fields present and correctly populated (`endDate` computed as 2.5h after `startDate`, matching the real feed's `DTEND`)
- [x] `bundle exec ruby tests/ruby/luma_event_generator_test.rb` — 3 new assertions covering both the has-end-date and no-end-date (`nil` `DTEND`) cases
- [x] `npx htmlhint`, `npm run lint`, `npm test` (Ruby + JS + CSS suites) — all pass
- [x] `npm run test:e2e` — all 84 Playwright tests pass
- [x] Independent code-review pass — verified both branches of the new Liquid `{% if %}` conditional render valid JSON, confirmed `performer`-as-Organization is schema.org-valid, and caught a minor "CivicTech" vs "Civic Tech" spelling inconsistency (fixed) between the new `description` and the existing `organizer`/`performer` fields in the same JSON block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmVDzx5KGck4SRwXsyU31w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Meeting event metadata now conditionally includes an `endDate` when an end time is available.
  * Improved event details with performer information, offer details (free/CAD), and a more descriptive hacknight summary.
  * Events without an end time continue to work correctly.
* **Bug Fixes**
  * Hardened calendar date/time parsing to avoid failures from malformed or out-of-range values.
* **Tests**
  * Added regression coverage for end-time formatting and more robust parsing behavior, including malformed feed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->