### PR TITLE
fix(seo): add validFrom to Event JSON-LD offers

### DIFF
--- a/_includes/meeting-section.html
+++ b/_includes/meeting-section.html
@@ -34,7 +34,8 @@ mtg.name | default: "CivicTechWR Hacknight" %}
       "url": {{ mtg_url | jsonify }},
       "price": "0",
       "priceCurrency": "CAD",
-      "availability": "https://schema.org/InStock"
+      "availability": "https://schema.org/InStock",
+      "validFrom": {{ site.time | date_to_xmlschema | jsonify }}
     },
     "description": "Join Civic Tech Waterloo Region for a free, weekly hacknight — a drop-in gathering where community members, designers, and technologists collaborate on local civic tech projects. Everyone is welcome, no tech skills required.",
     "url": {{ mtg_url | jsonify }},


### PR DESCRIPTION
## Summary
Google Search Console flagged a 5th Event structured data issue after #162 added the `offers` object: missing `validFrom`.

Considered using the Luma iCal feed's `DTSTAMP` field for a real per-event value, but checked the fixtures first — it's identical across every event in a given feed fetch (a feed-generation timestamp, not a true per-event creation date), so surfacing it as `validFrom` would misrepresent it as more specific than it actually is. Used Jekyll's built-in `site.time` (the page's own build timestamp) instead — it honestly represents "the free RSVP offer was open as of this page being published," with no Ruby plugin changes needed.

## Test plan
- [x] `bundle exec jekyll build` — reparsed the built Event JSON-LD with `json.loads` to confirm valid JSON with a correctly-formatted ISO8601-with-offset `validFrom`
- [x] `npx htmlhint`, `npm test`, `npm run lint` — all pass
- [x] `npm run test:e2e` — all 84 Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmVDzx5KGck4SRwXsyU31w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a start date to meeting offer metadata, improving the accuracy and completeness of structured event information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->